### PR TITLE
1.20.1 forge 47.1 compat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ run
 
 # Files from Forge MDK
 forge*changelog.txt
+
+# For Nix flake dev environment
+.envrc
+flake.nix
+flake.lock

--- a/gradle.properties
+++ b/gradle.properties
@@ -50,7 +50,7 @@ mod_name=Mutants and Zombies
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=All Rights Reserved
 # The mod version. See https://semver.org/
-mod_version=1.3.2-Forge-mc1.20.1
+mod_version=1.3.2-Forge47.1-mc1.20.1
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/net/petemc/mutantszombies/MutantsZombies.java
+++ b/src/main/java/net/petemc/mutantszombies/MutantsZombies.java
@@ -12,7 +12,8 @@ import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.event.server.ServerStartingEvent;
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.fml.ModContainer;
+import net.minecraftforge.fml.ModLoadingContext;
 import net.petemc.mutantszombies.config.Config;
 import net.petemc.mutantszombies.entity.*;
 import net.petemc.mutantszombies.item.ModItems;
@@ -28,9 +29,7 @@ public class MutantsZombies
     // Directly reference a slf4j logger
     public static final Logger LOGGER = LogUtils.getLogger();
 
-    public MutantsZombies(FMLJavaModLoadingContext context) {
-        IEventBus modEventBus = context.getModEventBus();
-
+    public MutantsZombies(IEventBus modEventBus) {
         // Register the commonSetup method for modloading
         modEventBus.addListener(this::commonSetup);
 
@@ -43,7 +42,7 @@ public class MutantsZombies
 
         // Register the item to a creative tab
         modEventBus.addListener(this::addCreative);
-        context.registerConfig(ModConfig.Type.SERVER, Config.SPEC_SERVER);
+        ModLoadingContext.get().registerConfig(ModConfig.Type.SERVER, Config.SPEC_SERVER);
     }
 
     private void commonSetup(final FMLCommonSetupEvent event)

--- a/src/main/java/net/petemc/mutantszombies/client/model/BlisterZombieModel.java
+++ b/src/main/java/net/petemc/mutantszombies/client/model/BlisterZombieModel.java
@@ -17,7 +17,7 @@ import net.petemc.mutantszombies.MutantsZombies;
 import net.petemc.mutantszombies.entity.BlisterZombieEntity;
 
 public class BlisterZombieModel<T extends BlisterZombieEntity> extends EntityModel<T> {
-    public static final ModelLayerLocation LAYER_LOCATION = new ModelLayerLocation(ResourceLocation.fromNamespaceAndPath(MutantsZombies.MOD_ID, "blister_zombie_layer"), "main");
+    public static final ModelLayerLocation LAYER_LOCATION = new ModelLayerLocation(new ResourceLocation(MutantsZombies.MOD_ID, "blister_zombie_layer"), "main");
     public final ModelPart head;
     public final ModelPart torso;
     public final ModelPart left_arm;

--- a/src/main/java/net/petemc/mutantszombies/client/model/CrawlerModel.java
+++ b/src/main/java/net/petemc/mutantszombies/client/model/CrawlerModel.java
@@ -18,7 +18,7 @@ import net.petemc.mutantszombies.entity.CrawlerEntity;
 import org.jetbrains.annotations.NotNull;
 
 public class CrawlerModel<T extends CrawlerEntity> extends EntityModel<T> {
-    public static final ModelLayerLocation LAYER_LOCATION = new ModelLayerLocation(ResourceLocation.fromNamespaceAndPath(MutantsZombies.MOD_ID, "crawler_layer"), "main");
+    public static final ModelLayerLocation LAYER_LOCATION = new ModelLayerLocation(new ResourceLocation(MutantsZombies.MOD_ID, "crawler_layer"), "main");
     public final ModelPart head;
     public final ModelPart torso;
     public final ModelPart left_arm;

--- a/src/main/java/net/petemc/mutantszombies/client/model/MutantBruteModel.java
+++ b/src/main/java/net/petemc/mutantszombies/client/model/MutantBruteModel.java
@@ -19,7 +19,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class MutantBruteModel<T extends MutantBruteEntity> extends EntityModel<T> {
     // This layer location should be baked with EntityRendererProvider.Context in the entity renderer and passed into this model's constructor
-    public static final ModelLayerLocation LAYER_LOCATION = new ModelLayerLocation(ResourceLocation.fromNamespaceAndPath(MutantsZombies.MOD_ID, "mutant_brute"), "main");
+    public static final ModelLayerLocation LAYER_LOCATION = new ModelLayerLocation(new ResourceLocation(MutantsZombies.MOD_ID, "mutant_brute"), "main");
     private final ModelPart head;
     //private final ModelPart blisterhead;
     //private final ModelPart Minihead;

--- a/src/main/java/net/petemc/mutantszombies/client/model/MutantZombieModel.java
+++ b/src/main/java/net/petemc/mutantszombies/client/model/MutantZombieModel.java
@@ -17,7 +17,7 @@ import net.petemc.mutantszombies.MutantsZombies;
 import net.petemc.mutantszombies.entity.MutantZombieEntity;
 
 public class MutantZombieModel<T extends MutantZombieEntity> extends EntityModel<T> {
-	public static final ModelLayerLocation LAYER_LOCATION = new ModelLayerLocation(ResourceLocation.fromNamespaceAndPath(MutantsZombies.MOD_ID, "mutant_zombie_layer"), "main");
+	public static final ModelLayerLocation LAYER_LOCATION = new ModelLayerLocation(new ResourceLocation(MutantsZombies.MOD_ID, "mutant_zombie_layer"), "main");
     private final ModelPart head;
     private final ModelPart teeth;
     private final ModelPart torso;

--- a/src/main/java/net/petemc/mutantszombies/client/model/RottenMutantModel.java
+++ b/src/main/java/net/petemc/mutantszombies/client/model/RottenMutantModel.java
@@ -14,7 +14,7 @@ import net.petemc.mutantszombies.MutantsZombies;
 
 public class RottenMutantModel<T extends Entity> extends EntityModel<T> {
 	// This layer location should be baked with EntityRendererProvider.Context in the entity renderer and passed into this model's constructor
-	public static final ModelLayerLocation LAYER_LOCATION = new ModelLayerLocation(ResourceLocation.fromNamespaceAndPath(MutantsZombies.MOD_ID, "rotten_mutant_layer"), "main");
+	public static final ModelLayerLocation LAYER_LOCATION = new ModelLayerLocation(new ResourceLocation(MutantsZombies.MOD_ID, "rotten_mutant_layer"), "main");
     private final ModelPart head;
     private final ModelPart torso;
     private final ModelPart metalrods;

--- a/src/main/java/net/petemc/mutantszombies/client/model/SpitterModel.java
+++ b/src/main/java/net/petemc/mutantszombies/client/model/SpitterModel.java
@@ -18,7 +18,7 @@ import net.petemc.mutantszombies.entity.SpitterEntity;
 import org.jetbrains.annotations.NotNull;
 
 public class SpitterModel<T extends SpitterEntity> extends EntityModel<T> {
-    public static final ModelLayerLocation LAYER_LOCATION = new ModelLayerLocation(ResourceLocation.fromNamespaceAndPath(MutantsZombies.MOD_ID, "spitter_layer"), "main");
+    public static final ModelLayerLocation LAYER_LOCATION = new ModelLayerLocation(new ResourceLocation(MutantsZombies.MOD_ID, "spitter_layer"), "main");
     public final ModelPart head2;
     public final ModelPart head3;
     public final ModelPart head4;

--- a/src/main/java/net/petemc/mutantszombies/client/model/SplitHeadZombieModel.java
+++ b/src/main/java/net/petemc/mutantszombies/client/model/SplitHeadZombieModel.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class SplitHeadZombieModel<T extends SplitHeadZombieEntity> extends EntityModel<T> {
 	// This layer location should be baked with EntityRendererProvider.Context in the entity renderer and passed into this model's constructor
-	public static final ModelLayerLocation LAYER_LOCATION = new ModelLayerLocation(ResourceLocation.fromNamespaceAndPath(MutantsZombies.MOD_ID, "split_head_zombie"), "main");
+	public static final ModelLayerLocation LAYER_LOCATION = new ModelLayerLocation(new ResourceLocation(MutantsZombies.MOD_ID, "split_head_zombie"), "main");
 	private final ModelPart head1;
 	//private final ModelPart bone3;
 	private final ModelPart head2;

--- a/src/main/java/net/petemc/mutantszombies/client/model/ZombieBruteModel.java
+++ b/src/main/java/net/petemc/mutantszombies/client/model/ZombieBruteModel.java
@@ -25,7 +25,7 @@ import net.petemc.mutantszombies.entity.ZombieBruteEntity;
 import org.jetbrains.annotations.NotNull;
 
 public class ZombieBruteModel<T extends ZombieBruteEntity> extends EntityModel<T> {
-    public static final ModelLayerLocation LAYER_LOCATION = new ModelLayerLocation(ResourceLocation.fromNamespaceAndPath(MutantsZombies.MOD_ID, "zombie_brute_layer"), "main");
+    public static final ModelLayerLocation LAYER_LOCATION = new ModelLayerLocation(new ResourceLocation(MutantsZombies.MOD_ID, "zombie_brute_layer"), "main");
     public final ModelPart head;
     public final ModelPart torso;
     public final ModelPart right_arm;

--- a/src/main/java/net/petemc/mutantszombies/client/renderer/BlisterZombieRenderer.java
+++ b/src/main/java/net/petemc/mutantszombies/client/renderer/BlisterZombieRenderer.java
@@ -15,6 +15,6 @@ public class BlisterZombieRenderer extends MobRenderer<BlisterZombieEntity, Blis
 
     @Override
     public @NotNull ResourceLocation getTextureLocation(@NotNull BlisterZombieEntity entity) {
-        return ResourceLocation.fromNamespaceAndPath(MutantsZombies.MOD_ID, "textures/entities/blisterzombie.png");
+        return new ResourceLocation(MutantsZombies.MOD_ID, "textures/entities/blisterzombie.png");
     }
 }

--- a/src/main/java/net/petemc/mutantszombies/client/renderer/CrawlerRenderer.java
+++ b/src/main/java/net/petemc/mutantszombies/client/renderer/CrawlerRenderer.java
@@ -15,7 +15,7 @@ public class CrawlerRenderer extends MobRenderer<CrawlerEntity, CrawlerModel<Cra
 
     @Override
     public @NotNull ResourceLocation getTextureLocation(@NotNull CrawlerEntity entity) {
-        return ResourceLocation.fromNamespaceAndPath(MutantsZombies.MOD_ID, "textures/entities/crawler.png");
+        return new ResourceLocation(MutantsZombies.MOD_ID, "textures/entities/crawler.png");
     }
 }
 

--- a/src/main/java/net/petemc/mutantszombies/client/renderer/MutantBruteRenderer.java
+++ b/src/main/java/net/petemc/mutantszombies/client/renderer/MutantBruteRenderer.java
@@ -15,6 +15,6 @@ public class MutantBruteRenderer extends MobRenderer<MutantBruteEntity, MutantBr
 
     @Override
     public @NotNull ResourceLocation getTextureLocation(@NotNull MutantBruteEntity pEntity) {
-        return ResourceLocation.fromNamespaceAndPath(MutantsZombies.MOD_ID, "textures/entities/mutantbrute.png");
+        return new ResourceLocation(MutantsZombies.MOD_ID, "textures/entities/mutantbrute.png");
     }
 }

--- a/src/main/java/net/petemc/mutantszombies/client/renderer/MutantZombieRenderer.java
+++ b/src/main/java/net/petemc/mutantszombies/client/renderer/MutantZombieRenderer.java
@@ -15,6 +15,6 @@ public class MutantZombieRenderer extends MobRenderer<MutantZombieEntity, Mutant
 
     @Override
     public @NotNull ResourceLocation getTextureLocation(@NotNull MutantZombieEntity entity) {
-        return ResourceLocation.fromNamespaceAndPath(MutantsZombies.MOD_ID, "textures/entities/mutantzombie.png");
+        return new ResourceLocation(MutantsZombies.MOD_ID, "textures/entities/mutantzombie.png");
     }
 }

--- a/src/main/java/net/petemc/mutantszombies/client/renderer/RottenMutantRenderer.java
+++ b/src/main/java/net/petemc/mutantszombies/client/renderer/RottenMutantRenderer.java
@@ -15,6 +15,6 @@ public class RottenMutantRenderer extends MobRenderer<RottenMutantEntity, Rotten
 
     @Override
     public @NotNull ResourceLocation getTextureLocation(@NotNull RottenMutantEntity entity) {
-        return ResourceLocation.fromNamespaceAndPath(MutantsZombies.MOD_ID, "textures/entities/rottenmutant.png");
+        return new ResourceLocation(MutantsZombies.MOD_ID, "textures/entities/rottenmutant.png");
     }
 }

--- a/src/main/java/net/petemc/mutantszombies/client/renderer/SpitterRenderer.java
+++ b/src/main/java/net/petemc/mutantszombies/client/renderer/SpitterRenderer.java
@@ -15,6 +15,6 @@ public class SpitterRenderer extends MobRenderer<SpitterEntity, SpitterModel<Spi
 
     @Override
     public @NotNull ResourceLocation getTextureLocation(@NotNull SpitterEntity entity) {
-        return ResourceLocation.fromNamespaceAndPath(MutantsZombies.MOD_ID, "textures/entities/spitter.png");
+        return new ResourceLocation(MutantsZombies.MOD_ID, "textures/entities/spitter.png");
     }
 }

--- a/src/main/java/net/petemc/mutantszombies/client/renderer/SplitHeadZombieRenderer.java
+++ b/src/main/java/net/petemc/mutantszombies/client/renderer/SplitHeadZombieRenderer.java
@@ -15,6 +15,6 @@ public class SplitHeadZombieRenderer extends MobRenderer<SplitHeadZombieEntity, 
 
     @Override
     public @NotNull ResourceLocation getTextureLocation(@NotNull SplitHeadZombieEntity pEntity) {
-        return ResourceLocation.fromNamespaceAndPath(MutantsZombies.MOD_ID, "textures/entities/splitheadzombie.png");
+        return new ResourceLocation(MutantsZombies.MOD_ID, "textures/entities/splitheadzombie.png");
     }
 }

--- a/src/main/java/net/petemc/mutantszombies/client/renderer/ZombieBruteRenderer.java
+++ b/src/main/java/net/petemc/mutantszombies/client/renderer/ZombieBruteRenderer.java
@@ -15,6 +15,6 @@ public class ZombieBruteRenderer extends MobRenderer<ZombieBruteEntity, ZombieBr
 
     @Override
     public @NotNull ResourceLocation getTextureLocation(@NotNull ZombieBruteEntity entity) {
-        return ResourceLocation.fromNamespaceAndPath(MutantsZombies.MOD_ID, "textures/entities/zombiebrute.png");
+        return new ResourceLocation(MutantsZombies.MOD_ID, "textures/entities/zombiebrute.png");
     }
 }

--- a/src/main/java/net/petemc/mutantszombies/entity/BlisterZombieEntity.java
+++ b/src/main/java/net/petemc/mutantszombies/entity/BlisterZombieEntity.java
@@ -64,19 +64,19 @@ public class BlisterZombieEntity extends Monster {
     }
 
     public SoundEvent getAmbientSound() {
-        return ForgeRegistries.SOUND_EVENTS.getValue(ResourceLocation.parse("block.sculk_shrieker.shriek"));
+        return ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("block.sculk_shrieker.shriek"));
     }
 
     public void playStepSound(@NotNull BlockPos pos, @NotNull BlockState blockIn) {
-        this.playSound(Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(ResourceLocation.parse("block.gravel.step"))), 0.15F, 1.0F);
+        this.playSound(Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("block.gravel.step"))), 0.15F, 1.0F);
     }
 
     public @NotNull SoundEvent getHurtSound(@NotNull DamageSource damageSource) {
-        return Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(ResourceLocation.parse("entity.zombie.hurt")));
+        return Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("entity.zombie.hurt")));
     }
 
     public @NotNull SoundEvent getDeathSound() {
-        return Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(ResourceLocation.parse("entity.husk.death")));
+        return Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("entity.husk.death")));
     }
 
     public boolean hurt(DamageSource damageSource, float amount) {

--- a/src/main/java/net/petemc/mutantszombies/entity/CrawlerEntity.java
+++ b/src/main/java/net/petemc/mutantszombies/entity/CrawlerEntity.java
@@ -70,19 +70,19 @@ public class CrawlerEntity extends Monster {
     }
 
     public SoundEvent getAmbientSound() {
-        return ForgeRegistries.SOUND_EVENTS.getValue(ResourceLocation.parse("entity.horse.breathe"));
+        return ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("entity.horse.breathe"));
     }
 
     public void playStepSound(@NotNull BlockPos blockPos, @NotNull BlockState blockState) {
-        this.playSound(Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(ResourceLocation.parse("block.cave_vines.step"))), 0.15F, 1.0F);
+        this.playSound(Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("block.cave_vines.step"))), 0.15F, 1.0F);
     }
 
     public @NotNull SoundEvent getHurtSound(@NotNull DamageSource damageSource) {
-        return Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(ResourceLocation.parse("entity.zombie.hurt")));
+        return Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("entity.zombie.hurt")));
     }
 
     public @NotNull SoundEvent getDeathSound() {
-        return Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(ResourceLocation.parse("entity.husk.death")));
+        return Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("entity.husk.death")));
     }
 
     /**

--- a/src/main/java/net/petemc/mutantszombies/entity/ModEntities.java
+++ b/src/main/java/net/petemc/mutantszombies/entity/ModEntities.java
@@ -86,7 +86,7 @@ public class ModEntities {
         SplitHeadZombieEntity.init();
         MutantBruteEntity.init();
         RottenMutantEntity.init();
-        MutantBruteEntity.init();
+        MutantZombieEntity.init();
     }
 
     public static void register(IEventBus eventBus) {

--- a/src/main/java/net/petemc/mutantszombies/entity/MutantBruteEntity.java
+++ b/src/main/java/net/petemc/mutantszombies/entity/MutantBruteEntity.java
@@ -73,15 +73,15 @@ public class MutantBruteEntity extends Monster {
     }
 
     public void playStepSound(@NotNull BlockPos pos, @NotNull BlockState blockIn) {
-        this.playSound(Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(ResourceLocation.parse("block.rooted_dirt.step"))), 0.15F, 1.0F);
+        this.playSound(Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("block.rooted_dirt.step"))), 0.15F, 1.0F);
     }
 
     public @NotNull SoundEvent getHurtSound(@NotNull DamageSource damageSource) {
-        return Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(ResourceLocation.parse("entity.husk.hurt")));
+        return Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("entity.husk.hurt")));
     }
 
     public @NotNull SoundEvent getDeathSound() {
-        return Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(ResourceLocation.parse("entity.zombie.death")));
+        return Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("entity.zombie.death")));
     }
 
     public boolean hurt(DamageSource damageSource, float amount) {

--- a/src/main/java/net/petemc/mutantszombies/entity/MutantZombieEntity.java
+++ b/src/main/java/net/petemc/mutantszombies/entity/MutantZombieEntity.java
@@ -67,19 +67,19 @@ public class MutantZombieEntity extends Monster {
     }
 
     public SoundEvent getAmbientSound() {
-        return ForgeRegistries.SOUND_EVENTS.getValue(ResourceLocation.parse("block.sculk_shrieker.shriek"));
+        return ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("block.sculk_shrieker.shriek"));
     }
 
     public void playStepSound(@NotNull BlockPos pos, @NotNull BlockState blockIn) {
-        this.playSound(Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(ResourceLocation.parse("block.gravel.step"))), 0.15F, 1.0F);
+        this.playSound(Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("block.gravel.step"))), 0.15F, 1.0F);
     }
 
     public @NotNull SoundEvent getHurtSound(@NotNull DamageSource damageSource) {
-        return Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(ResourceLocation.parse("entity.zombie.hurt")));
+        return Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("entity.zombie.hurt")));
     }
 
     public @NotNull SoundEvent getDeathSound() {
-        return Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(ResourceLocation.parse("entity.husk.death")));
+        return Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("entity.husk.death")));
     }
 
     public boolean hurt(DamageSource damageSource, float amount) {

--- a/src/main/java/net/petemc/mutantszombies/entity/RottenMutantEntity.java
+++ b/src/main/java/net/petemc/mutantszombies/entity/RottenMutantEntity.java
@@ -67,19 +67,19 @@ public class RottenMutantEntity extends Monster {
     }
 
     public SoundEvent getAmbientSound() {
-        return ForgeRegistries.SOUND_EVENTS.getValue(ResourceLocation.parse("entity.husk.ambient"));
+        return ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("entity.husk.ambient"));
     }
 
     public void playStepSound(@NotNull BlockPos pos, @NotNull BlockState blockIn) {
-        this.playSound(Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(ResourceLocation.parse("block.gravel.step"))), 0.15F, 1.0F);
+        this.playSound(Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("block.gravel.step"))), 0.15F, 1.0F);
     }
 
     public @NotNull SoundEvent getHurtSound(@NotNull DamageSource damageSource) {
-        return Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(ResourceLocation.parse("entity.husk.hurt")));
+        return Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("entity.husk.hurt")));
     }
 
     public @NotNull SoundEvent getDeathSound() {
-        return Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(ResourceLocation.parse("entity.husk.death")));
+        return Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("entity.husk.death")));
     }
 
     public boolean hurt(DamageSource damageSource, float amount) {

--- a/src/main/java/net/petemc/mutantszombies/entity/SpitterEntity.java
+++ b/src/main/java/net/petemc/mutantszombies/entity/SpitterEntity.java
@@ -75,19 +75,19 @@ public class SpitterEntity extends Monster implements RangedAttackMob {
     }
 
     public SoundEvent getAmbientSound() {
-        return ForgeRegistries.SOUND_EVENTS.getValue(ResourceLocation.parse("entity.player.burp"));
+        return ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("entity.player.burp"));
     }
 
     public void playStepSound(@NotNull BlockPos blockPos, @NotNull BlockState blockState) {
-        this.playSound(Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(ResourceLocation.parse("block.basalt.step"))), 0.15F, 1.0F);
+        this.playSound(Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("block.basalt.step"))), 0.15F, 1.0F);
     }
 
     public @NotNull SoundEvent getHurtSound(@NotNull DamageSource damageSource) {
-        return Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(ResourceLocation.parse("entity.zombie.hurt")));
+        return Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("entity.zombie.hurt")));
     }
 
     public @NotNull SoundEvent getDeathSound() {
-        return Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(ResourceLocation.parse("entity.husk.death")));
+        return Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("entity.husk.death")));
     }
 
     public boolean hurt(DamageSource damageSource, float amount) {

--- a/src/main/java/net/petemc/mutantszombies/entity/SplitHeadZombieEntity.java
+++ b/src/main/java/net/petemc/mutantszombies/entity/SplitHeadZombieEntity.java
@@ -67,7 +67,7 @@ public class SplitHeadZombieEntity extends Monster {
     }
 
     public void playStepSound(@NotNull BlockPos pos, @NotNull BlockState blockIn) {
-        this.playSound(Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(ResourceLocation.parse("block.gravel.step"))), 0.15F, 1.0F);
+        this.playSound(Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("block.gravel.step"))), 0.15F, 1.0F);
     }
 
     public @NotNull SoundEvent getHurtSound(@NotNull DamageSource damageSource) {
@@ -75,7 +75,7 @@ public class SplitHeadZombieEntity extends Monster {
     }
 
     public @NotNull SoundEvent getDeathSound() {
-        return Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(ResourceLocation.parse("entity.zombie.death")));
+        return Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("entity.zombie.death")));
     }
 
     public boolean hurt(DamageSource damageSource, float amount) {

--- a/src/main/java/net/petemc/mutantszombies/entity/ZombieBruteEntity.java
+++ b/src/main/java/net/petemc/mutantszombies/entity/ZombieBruteEntity.java
@@ -79,15 +79,15 @@ public class ZombieBruteEntity extends Monster {
     }
 
     public void playStepSound(@NotNull BlockPos pos, @NotNull BlockState blockIn) {
-        this.playSound(Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(ResourceLocation.parse("block.rooted_dirt.step"))), 0.15F, 1.0F);
+        this.playSound(Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("block.rooted_dirt.step"))), 0.15F, 1.0F);
     }
 
     public @NotNull SoundEvent getHurtSound(@NotNull DamageSource ds) {
-        return Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(ResourceLocation.parse("entity.zombie.hurt")));
+        return Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("entity.zombie.hurt")));
     }
 
     public @NotNull SoundEvent getDeathSound() {
-        return Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(ResourceLocation.parse("entity.zombie.death")));
+        return Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("entity.zombie.death")));
     }
 
     public boolean hurt(DamageSource damageSource, float amount) {


### PR DESCRIPTION
    Fix mod compatibility with Forge 47.1.106

I'm not exactly sure how I got in this situation, but I have NeoForge 47.1.106, which is apparently *actually* just Forge (I think this version was some time during the fork to NeoForged). In any case, PrismLauncher deemed the MutantZombies mod to be compatible with that loader and MC 1.20.1. However, it won't launch because the constructor args between NeoForged and Forge are different.

I wanted to use this mod, with my existing modpack that had a bunch of stuff already (so I couldn't just use a different version), so I fixed the compatibility.

I'm completely new to the MC modding ecosystem, so I'm not sure if I'm missing something totally obvious. But this works and I can play the mod now, so I'm using it at least!

*I'm also including a fix to a copy-paste error (I think) made back in November that duplicated a registration value*. That could be separate, but since the mod doesn't work without that fix (on this branch) I'm including it.
    
    Changes made to work with Forge 47.1.x (used in transition to NeoForge):
    - Changed constructor from FMLJavaModLoadingContext to IEventBus
    - Updated config registration to use ModLoadingContext.get()
    - Updated version to 1.3.2-Forge47.1-mc1.20.1
    - Replaced ResourceLocation.fromNamespaceAndPath() with the constructor new ResourceLocation() which is the correct method for MC 1.20.1.
    - Fix ResourceLocation.parse() compatibility (doesn't exist in MC 1.20.1)
    
    This fixes the "Could not find mod constructor" error when loading
    the mod with Forge 47.1.106 on Minecraft 1.20.1.
    
    The issue was that Forge 47.1.106 (transitional version) expects:
    - ModContainer, IEventBus, or FMLModContainer as constructor params
    But the original mod (built for Forge 47.4.6) used:
    - FMLJavaModLoadingContext
    
    Tested with Forge 47.1.106 on Minecraft 1.20.1.
